### PR TITLE
Keyboard toggle & navigation from notification

### DIFF
--- a/zeitgeist/zeitgeist.xcodeproj/project.pbxproj
+++ b/zeitgeist/zeitgeist.xcodeproj/project.pbxproj
@@ -28,6 +28,11 @@
 		035C56BA242937C700139C8E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C56B9242937C700139C8E /* ProfileView.swift */; };
 		035C56BB242937C700139C8E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C56B9242937C700139C8E /* ProfileView.swift */; };
 		035C56BC242937C700139C8E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C56B9242937C700139C8E /* ProfileView.swift */; };
+		0364AE84243279DE005AB2A4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034EF88B2423D99200741711 /* ContentView.swift */; };
+		0398157924328FCD00C168D8 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0398157824328FCD00C168D8 /* SearchBar.swift */; };
+		0398157A24328FCD00C168D8 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0398157824328FCD00C168D8 /* SearchBar.swift */; };
+		039815822432C70700C168D8 /* HideKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039815812432C70700C168D8 /* HideKeyboard.swift */; };
+		039815832432C70700C168D8 /* HideKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039815812432C70700C168D8 /* HideKeyboard.swift */; };
 		03A2DD212431742D007A1387 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A2DD202431742D007A1387 /* Notification.swift */; };
 		03A2DD222431742D007A1387 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A2DD202431742D007A1387 /* Notification.swift */; };
 		03F1DF9724311A8100BD9E19 /* SingleResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F1DF9624311A8100BD9E19 /* SingleResult.swift */; };
@@ -85,6 +90,8 @@
 		035C56B12429376E00139C8E /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		035C56B5242937A900139C8E /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		035C56B9242937C700139C8E /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		0398157824328FCD00C168D8 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		039815812432C70700C168D8 /* HideKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HideKeyboard.swift; sourceTree = "<group>"; };
 		03A2DD202431742D007A1387 /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		03F1DF9624311A8100BD9E19 /* SingleResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleResult.swift; sourceTree = "<group>"; };
 		03F1DF9924311ABD00BD9E19 /* NetworkingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingManager.swift; sourceTree = "<group>"; };
@@ -153,6 +160,8 @@
 				03F1DFAE24311D0100BD9E19 /* DataView.swift */,
 				03A2DD202431742D007A1387 /* Notification.swift */,
 				035C56B12429376E00139C8E /* HomeView.swift */,
+				039815812432C70700C168D8 /* HideKeyboard.swift */,
+				0398157824328FCD00C168D8 /* SearchBar.swift */,
 				035C56B5242937A900139C8E /* SearchView.swift */,
 				035C56B9242937C700139C8E /* ProfileView.swift */,
 				035C56AD2429369800139C8E /* NavigationBarView.swift */,
@@ -350,6 +359,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				039815822432C70700C168D8 /* HideKeyboard.swift in Sources */,
 				03F1DFAF24311D0100BD9E19 /* DataView.swift in Sources */,
 				03F1DF9D24311AD900BD9E19 /* Course.swift in Sources */,
 				034EF8852423D99200741711 /* AppDelegate.swift in Sources */,
@@ -367,6 +377,7 @@
 				03F1DFA924311CA600BD9E19 /* ImageLoader.swift in Sources */,
 				03A2DD212431742D007A1387 /* Notification.swift in Sources */,
 				03F1DF9A24311ABD00BD9E19 /* NetworkingManager.swift in Sources */,
+				0398157924328FCD00C168D8 /* SearchBar.swift in Sources */,
 				034EF88C2423D99200741711 /* ContentView.swift in Sources */,
 				034EF88A2423D99200741711 /* zeitgeist.xcdatamodeld in Sources */,
 			);
@@ -378,8 +389,10 @@
 			files = (
 				03F1DFA724311BD000BD9E19 /* CampaignView.swift in Sources */,
 				03F1DF9E24311AD900BD9E19 /* Course.swift in Sources */,
+				0364AE84243279DE005AB2A4 /* ContentView.swift in Sources */,
 				035C56B7242937A900139C8E /* SearchView.swift in Sources */,
 				035C56B32429376E00139C8E /* HomeView.swift in Sources */,
+				039815832432C70700C168D8 /* HideKeyboard.swift in Sources */,
 				03F1DFA124311AFD00BD9E19 /* CampaingNetworkManager.swift in Sources */,
 				03F1DFA424311BAC00BD9E19 /* ImageViewComponent.swift in Sources */,
 				035C56BB242937C700139C8E /* ProfileView.swift in Sources */,
@@ -389,6 +402,7 @@
 				03A2DD222431742D007A1387 /* Notification.swift in Sources */,
 				03F1DF9824311A8100BD9E19 /* SingleResult.swift in Sources */,
 				034EF89F2423D99400741711 /* zeitgeistTests.swift in Sources */,
+				0398157A24328FCD00C168D8 /* SearchBar.swift in Sources */,
 				03F1DFAA24311CA600BD9E19 /* ImageLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -642,7 +656,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.zteam.zeitgeistUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = zeitgeist;
 			};
 			name = Debug;
@@ -661,7 +675,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.zteam.zeitgeistUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = zeitgeist;
 			};
 			name = Release;

--- a/zeitgeist/zeitgeist/AppDelegate.swift
+++ b/zeitgeist/zeitgeist/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         
-        if response.actionIdentifier == "open" {
+        if response.actionIdentifier != "cancel" {
             NotificationCenter.default.post(name: NSNotification.Name("Detail"), object: nil)
         }
     }

--- a/zeitgeist/zeitgeist/ContentView.swift
+++ b/zeitgeist/zeitgeist/ContentView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct ContentView: View {
     
     var body: some View {
-
         NavigationBarView()
     }
 }
@@ -20,7 +19,6 @@ struct ContentView_Previews: PreviewProvider {
         Group {
            ContentView()
               .environment(\.colorScheme, .light)
-
            ContentView()
               .environment(\.colorScheme, .dark)
         }

--- a/zeitgeist/zeitgeist/HideKeyboard.swift
+++ b/zeitgeist/zeitgeist/HideKeyboard.swift
@@ -1,0 +1,45 @@
+//
+//  HideKeyboard.swift
+//  zeitgeist
+//
+//  Created by Jari Pietikäinen on 31.3.2020.
+//  Copyright © 2020 Z Team. All rights reserved.
+//
+
+import SwiftUI
+
+extension UIApplication {
+    func endEditing(_ force: Bool) {
+        self.windows
+            .filter{$0.isKeyWindow}
+            .first?
+            .endEditing(force)
+    }
+}
+
+struct ResignKeyboardOnDragGesture: ViewModifier {
+    var gesture = DragGesture().onChanged{_ in
+        UIApplication.shared.endEditing(true)
+    }
+    func body(content: Content) -> some View {
+        content.gesture(gesture)
+    }
+}
+
+extension View {
+    func resignKeyboardOnDragGesture() -> some View {
+        modifier(ResignKeyboardOnDragGesture())
+    }
+}
+// Put this piece of code anywhere you like
+extension UIViewController {
+    func hideKeyboardWhenTappedAround() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/zeitgeist/zeitgeist/Notification.swift
+++ b/zeitgeist/zeitgeist/Notification.swift
@@ -36,7 +36,7 @@ class Notification {
         
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
         
-        let request = UNNotificationRequest(identifier: "request", content: content, trigger: trigger)
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
         
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
     }

--- a/zeitgeist/zeitgeist/SearchBar.swift
+++ b/zeitgeist/zeitgeist/SearchBar.swift
@@ -1,0 +1,62 @@
+//
+//  SearchBar.swift
+//  zeitgeist
+//
+//  Created by Jari Pietikäinen on 30.3.2020.
+//  Copyright © 2020 Z Team. All rights reserved.
+//
+
+import SwiftUI
+
+struct SearchBar: UIViewRepresentable {
+    
+    @Binding var text: String
+    var placeholder: String
+    
+    class Coordinator: NSObject, UISearchBarDelegate {
+        
+        @Binding var text: String
+        
+        init(text: Binding<String>) {
+            _text = text
+        }
+        
+        func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+            text = searchText
+            searchBar.showsCancelButton = true
+        }
+        
+        func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+            searchBar.showsCancelButton = true
+        }
+        
+        func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+            searchBar.resignFirstResponder()
+        }
+        
+        func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+            //searchBar.text = ""
+            searchBar.resignFirstResponder()
+            searchBar.showsCancelButton = false
+            searchBar.endEditing(true)
+        }
+    }
+    
+    func makeCoordinator() -> SearchBar.Coordinator {
+        return Coordinator(text: $text)
+    }
+    
+    func makeUIView(context: UIViewRepresentableContext<SearchBar>) -> UISearchBar {
+        let searchBar = UISearchBar(frame: .zero)
+        searchBar.delegate = context.coordinator
+        searchBar.placeholder = placeholder
+        searchBar.searchBarStyle = .minimal
+        searchBar.autocapitalizationType = .none
+        searchBar.showsCancelButton = true
+        return searchBar
+    }
+    
+    func updateUIView(_ uiView: UISearchBar, context: UIViewRepresentableContext<SearchBar>) {
+        uiView.text = text
+    }
+}

--- a/zeitgeist/zeitgeist/SearchView.swift
+++ b/zeitgeist/zeitgeist/SearchView.swift
@@ -11,101 +11,74 @@ import SwiftUI
 struct SearchView: View {
     @ObservedObject var networkingManager = NetworkingManager()
     @State private var searchText : String = ""
-    var notification = Notification()
     
     var body: some View {
-        VStack {
-            SearchBar(text: $searchText, placeholder: "Search items").padding(12)
-            NavigationView {
-                List {
-                    ForEach(networkingManager.clothingList.items) { item in
-                        if (self.searchText.isEmpty) {
-                            NavigationLink(destination: VStack {
-                                Text(item.brand).font(.largeTitle)
-                                Text(item.size)
-                                Text(item.condition)
-                                //Text(item.description)
-                                Text("\(item.price) €")
-                                    .font(.system(size: 20))
-                                    .foregroundColor(Color.orange)
-                            }) {
-                                VStack {
-                                    Text(item.brand)
-                                    Text(item.size)
-                                        .font(.system(size: 11))
-                                        .foregroundColor(Color.gray)
-                                    Text("\(item.price) €")
-                                        .font(.system(size: 11))
-                                        .foregroundColor(Color.orange)
+        VStack(alignment: .leading) {
+            NavigationView{
+                VStack {
+                    SearchBar(text: $searchText, placeholder: "Search items")
+                    List {
+                        ForEach(networkingManager.clothingList.items) { item in
+                            if (self.searchText.isEmpty) {
+                                NavigationLink(destination:
+                                    VStack(alignment: .leading) {
+                                        Text(item.brand).font(.largeTitle)
+                                        Text(item.size)
+                                        Text(item.condition)
+                                        Text(item.description)
+                                        Text("\(item.price) €")
+                                            .font(.system(size: 20))
+                                            .foregroundColor(Color.orange)
+                                    }.onAppear {
+                                        UIApplication.shared.endEditing(true)
+                                }) {
+                                    VStack(alignment: .leading) {
+                                        Text(item.brand)
+                                        Text(item.size)
+                                            .font(.system(size: 11))
+                                            .foregroundColor(Color.gray)
+                                        Text("\(item.price) €")
+                                            .font(.system(size: 11))
+                                            .foregroundColor(Color.orange)
+                                    }
                                 }
                             }
-                        }
-                        if (item.brand.lowercased().contains(self.searchText.lowercased())) {
-                            NavigationLink(destination: VStack {
-                                Text(item.brand).font(.largeTitle)
-                                Text(item.size)
-                                Text(item.condition)
-                                Text("\(item.price) €")
-                                    .font(.system(size: 20))
-                                    .foregroundColor(Color.orange)
-                            }) {
-                                VStack {
-                                    Text(item.brand)
-                                    Text(item.size)
-                                        .font(.system(size: 11))
-                                        .foregroundColor(Color.gray)
-                                    Text("\(item.price) €")
-                                        .font(.system(size: 11))
-                                        .foregroundColor(Color.orange)
+                            if (item.brand.lowercased().contains(self.searchText.lowercased())) {
+                                NavigationLink(destination:
+                                    VStack(alignment: .leading) {
+                                        Text(item.brand).font(.largeTitle)
+                                        Text(item.size)
+                                        Text(item.condition)
+                                        Text("\(item.price) €")
+                                            .font(.system(size: 20))
+                                            .foregroundColor(Color.orange)
+                                    }.onAppear {
+                                        UIApplication.shared.endEditing(true)
+                                }) {
+                                    VStack(alignment: .leading) {
+                                        Text(item.brand)
+                                        Text(item.size)
+                                            .font(.system(size: 11))
+                                            .foregroundColor(Color.gray)
+                                        Text("\(item.price) €")
+                                            .font(.system(size: 11))
+                                            .foregroundColor(Color.orange)
+                                    }
                                 }
                             }
                         }
                     }
-                }
-            }.navigationBarTitle(Text("Marketplace"))
-            
-        }
+                }.frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
+                    .navigationBarItems(leading: Image(systemName: "house").font(Font.system(size: 30, weight: .regular))).navigationBarTitle(Text("Search Items"))
+            }
+        }.resignKeyboardOnDragGesture()
     }
 }
 
-struct SearchBar: UIViewRepresentable {
-    
-    @Binding var text: String
-    var placeholder: String
-    
-    class Coordinator: NSObject, UISearchBarDelegate {
-        
-        @Binding var text: String
-        
-        init(text: Binding<String>) {
-            _text = text
-        }
-        
-        func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-            text = searchText
-        }
-    }
-    
-    func makeCoordinator() -> SearchBar.Coordinator {
-        return Coordinator(text: $text)
-    }
-    
-    func makeUIView(context: UIViewRepresentableContext<SearchBar>) -> UISearchBar {
-        let searchBar = UISearchBar(frame: .zero)
-        searchBar.delegate = context.coordinator
-        searchBar.placeholder = placeholder
-        searchBar.searchBarStyle = .minimal
-        searchBar.autocapitalizationType = .none
-        return searchBar
-    }
-    
-    func updateUIView(_ uiView: UISearchBar, context: UIViewRepresentableContext<SearchBar>) {
-        uiView.text = text
-    }
-}
 
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
         SearchView()
     }
 }
+


### PR DESCRIPTION
Closes #28 
Ables users to hide the on screen keyboard during search by dragging down or by button.
(Also hides it after using navigationLink)